### PR TITLE
removed 'results = ' from python writer output

### DIFF
--- a/src/gauge/python_printer.cpp
+++ b/src/gauge/python_printer.cpp
@@ -50,7 +50,6 @@ namespace gauge
     void python_printer::end()
     {
         m_out.open(m_filename, std::ios::trunc);
-        m_out << "results = ";
 
         python_format f;
         f.print(m_out, m_list);


### PR DESCRIPTION
To make it easier to use, I've removed the 'results =' from the python output. Is this OK? 
