### PR TITLE
Add copyright comments referring to LICENSE.rst

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
 gauge licence
 -------------
-gauge is provided under the "New BSD License":
-::
+gauge is provided under the "New BSD License"::
+
   Copyright (c) 2012, Steinwurf ApS
   All rights reserved.
 
@@ -12,9 +12,9 @@ gauge is provided under the "New BSD License":
       * Redistributions in binary form must reproduce the above copyright
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
-      * Neither the name of Steinwurf ApS nor the
-        names of its contributors may be used to endorse or promote products
-        derived from this software without specific prior written permission.
+      * Neither the name of Steinwurf ApS nor the names of its contributors
+        may be used to endorse or promote products derived from this software
+        without specific prior written permission.
 
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/examples/sample_benchmarks/custom_measurement.cpp
+++ b/examples/sample_benchmarks/custom_measurement.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <gauge/gauge.hpp>
 #include <tables/table.hpp>
 #include <cstdlib>

--- a/examples/sample_benchmarks/main.cpp
+++ b/examples/sample_benchmarks/main.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <ctime>
 
 #include <gauge/gauge.hpp>

--- a/examples/sample_benchmarks/run_outside_benchmark.cpp
+++ b/examples/sample_benchmarks/run_outside_benchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <list>
 #include <vector>
 #include <cstdlib>

--- a/examples/sample_benchmarks/simple_fixture.cpp
+++ b/examples/sample_benchmarks/simple_fixture.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <algorithm>
 #include <list>
 

--- a/examples/sample_benchmarks/simple_run.cpp
+++ b/examples/sample_benchmarks/simple_run.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <gauge/gauge.hpp>
 #include <cstdlib>
 

--- a/examples/sample_benchmarks/using_configurations.cpp
+++ b/examples/sample_benchmarks/using_configurations.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <algorithm>
 #include <numeric>
 

--- a/examples/sample_benchmarks/using_options.cpp
+++ b/examples/sample_benchmarks/using_options.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <algorithm>
 #include <numeric>
 

--- a/src/gauge/benchmark.hpp
+++ b/src/gauge/benchmark.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <cassert>

--- a/src/gauge/config_set.hpp
+++ b/src/gauge/config_set.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <iostream>

--- a/src/gauge/console_colors.cpp
+++ b/src/gauge/console_colors.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include "console_colors.hpp"
 
 // The preprocessor defines are taken from

--- a/src/gauge/console_printer.hpp
+++ b/src/gauge/console_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <iomanip>

--- a/src/gauge/csv_printer.cpp
+++ b/src/gauge/csv_printer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <ostream>
 
 #include <boost/program_options.hpp>

--- a/src/gauge/csv_printer.hpp
+++ b/src/gauge/csv_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <string>

--- a/src/gauge/file_printer.cpp
+++ b/src/gauge/file_printer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <cassert>
 #include <fstream>
 #include <iostream>

--- a/src/gauge/file_printer.hpp
+++ b/src/gauge/file_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <string>

--- a/src/gauge/gauge.hpp
+++ b/src/gauge/gauge.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include "iteration_controller.hpp"

--- a/src/gauge/iteration_controller.hpp
+++ b/src/gauge/iteration_controller.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include "benchmark.hpp"

--- a/src/gauge/json_printer.cpp
+++ b/src/gauge/json_printer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <ostream>
 #include <tables/json_format.hpp>
 

--- a/src/gauge/json_printer.hpp
+++ b/src/gauge/json_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <ostream>

--- a/src/gauge/printer.cpp
+++ b/src/gauge/printer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <cassert>
 #include <fstream>
 #include <iostream>

--- a/src/gauge/printer.hpp
+++ b/src/gauge/printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <tables/table.hpp>

--- a/src/gauge/python_printer.cpp
+++ b/src/gauge/python_printer.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <ostream>
 #include <tables/python_format.hpp>
 

--- a/src/gauge/python_printer.hpp
+++ b/src/gauge/python_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <ostream>

--- a/src/gauge/results.hpp
+++ b/src/gauge/results.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <vector>

--- a/src/gauge/runner.cpp
+++ b/src/gauge/runner.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <cassert>
 #include <cstdlib>
 

--- a/src/gauge/runner.hpp
+++ b/src/gauge/runner.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <vector>

--- a/src/gauge/statistics.hpp
+++ b/src/gauge/statistics.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <algorithm>

--- a/src/gauge/stdout_printer.cpp
+++ b/src/gauge/stdout_printer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
 #include <tables/csv_format.hpp>
 #include <tables/json_format.hpp>

--- a/src/gauge/stdout_printer.hpp
+++ b/src/gauge/stdout_printer.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <tables/format.hpp>

--- a/src/gauge/time_benchmark.cpp
+++ b/src/gauge/time_benchmark.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <boost/chrono.hpp>
 
 #include "time_benchmark.hpp"

--- a/src/gauge/time_benchmark.hpp
+++ b/src/gauge/time_benchmark.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #pragma once
 
 #include <memory>

--- a/test/gauge_tests.cpp
+++ b/test/gauge_tests.cpp
@@ -1,7 +1,7 @@
-// Copyright Steinwurf ApS 2011-2012.
-// Distributed under the "STEINWURF RESEARCH LICENSE 1.0".
-// See accompanying file LICENSE.rst or
-// http://www.steinwurf.com/licensing
+// Copyright (c) 2012 Steinwurf ApS
+// All Rights Reserved
+//
+// Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
 #include <cstdint>
 #include <ctime>


### PR DESCRIPTION
@mortenvp @jpihl The copyright comments are added. One exception: the console_printer files were partly borrowed from a library written by Nick Bruun, so it seems fair to leave that comment.
